### PR TITLE
Gpsanant/perf updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -827,6 +829,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1075,7 @@ dependencies = [
  "alloy-primitives",
  "ruint",
  "sha3",
+ "zstd",
 ]
 
 [[package]]
@@ -1804,3 +1823,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ debug = false
 alloy-primitives = "1.5"
 ruint = "1.12"
 sha3 = "0.10"
+zstd = "0.13"

--- a/src/bin/build_circuit.rs
+++ b/src/bin/build_circuit.rs
@@ -8,7 +8,8 @@
 
 use quantum_ecc::circuit::Op;
 use quantum_ecc::point_add;
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 const OPS_PATH: &str = "ops.bin";
@@ -25,21 +26,26 @@ const MAGIC: &[u8; 8] = b"QECCOPS1";
 const OP_BYTES: usize = 56;
 
 fn write_ops(ops: &[Op], path: &Path) -> std::io::Result<()> {
-    let mut buf = Vec::with_capacity(MAGIC.len() + 8 + ops.len() * OP_BYTES);
-    buf.extend_from_slice(MAGIC);
-    buf.extend_from_slice(&(ops.len() as u64).to_le_bytes());
-    for op in ops {
-        buf.extend_from_slice(&(op.kind as u32).to_le_bytes());
-        buf.extend_from_slice(&[0u8; 4]); // pad
-        buf.extend_from_slice(&op.q_control2.0.to_le_bytes());
-        buf.extend_from_slice(&op.q_control1.0.to_le_bytes());
-        buf.extend_from_slice(&op.q_target.0.to_le_bytes());
-        buf.extend_from_slice(&op.c_target.0.to_le_bytes());
-        buf.extend_from_slice(&op.c_condition.0.to_le_bytes());
-        buf.extend_from_slice(&op.r_target.0.to_le_bytes());
-    }
     let tmp = path.with_extension("bin.tmp");
-    fs::write(&tmp, &buf)?;
+    let mut w = BufWriter::new(File::create(&tmp)?);
+    w.write_all(MAGIC)?;
+    w.write_all(&(ops.len() as u64).to_le_bytes())?;
+    // Serialize each op into a fixed 56-byte record and stream it out, so we
+    // never materialize a second full copy of the op stream in memory.
+    let mut rec = [0u8; OP_BYTES];
+    for op in ops {
+        rec[0..4].copy_from_slice(&(op.kind as u32).to_le_bytes());
+        rec[4..8].copy_from_slice(&[0u8; 4]); // pad
+        rec[8..16].copy_from_slice(&op.q_control2.0.to_le_bytes());
+        rec[16..24].copy_from_slice(&op.q_control1.0.to_le_bytes());
+        rec[24..32].copy_from_slice(&op.q_target.0.to_le_bytes());
+        rec[32..40].copy_from_slice(&op.c_target.0.to_le_bytes());
+        rec[40..48].copy_from_slice(&op.c_condition.0.to_le_bytes());
+        rec[48..56].copy_from_slice(&op.r_target.0.to_le_bytes());
+        w.write_all(&rec)?;
+    }
+    w.flush()?;
+    drop(w);
     fs::rename(&tmp, path)?;
     Ok(())
 }

--- a/src/bin/build_circuit.rs
+++ b/src/bin/build_circuit.rs
@@ -13,7 +13,12 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 const OPS_PATH: &str = "ops.bin";
-const MAGIC: &[u8; 8] = b"QECCOPS1";
+// "Z" suffix marks the zstd-compressed framing (was "QECCOPS1", uncompressed).
+const MAGIC: &[u8; 8] = b"QECCOPSZ";
+// zstd compression level. The record stream is almost pure boilerplate
+// (zero pad bytes, NO_QUBIT sentinels, near-sequential ids), so even the
+// fast default crushes it ~40x. Override with ZSTD_LEVEL for smaller/slower.
+const DEFAULT_ZSTD_LEVEL: i32 = 3;
 
 // Per-op layout (56 bytes, all little-endian):
 //   u32  kind     | u32 _pad
@@ -25,13 +30,26 @@ const MAGIC: &[u8; 8] = b"QECCOPS1";
 //   u64  r_target
 const OP_BYTES: usize = 56;
 
+fn zstd_level() -> i32 {
+    std::env::var("ZSTD_LEVEL")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(DEFAULT_ZSTD_LEVEL)
+}
+
 fn write_ops(ops: &[Op], path: &Path) -> std::io::Result<()> {
     let tmp = path.with_extension("bin.tmp");
     let mut w = BufWriter::new(File::create(&tmp)?);
+    // Header stays uncompressed so the trusted loader can read MAGIC and the
+    // op count (to bound memory) before touching the compressed body.
     w.write_all(MAGIC)?;
     w.write_all(&(ops.len() as u64).to_le_bytes())?;
-    // Serialize each op into a fixed 56-byte record and stream it out, so we
-    // never materialize a second full copy of the op stream in memory.
+
+    // Compress the record body. The encoder owns the BufWriter; finish()
+    // flushes the zstd frame and hands it back.
+    let mut enc = zstd::stream::write::Encoder::new(w, zstd_level())?;
+    // Serialize each op into a fixed 56-byte record and stream it through the
+    // encoder, so we never materialize a second full copy of the op stream.
     let mut rec = [0u8; OP_BYTES];
     for op in ops {
         rec[0..4].copy_from_slice(&(op.kind as u32).to_le_bytes());
@@ -42,8 +60,9 @@ fn write_ops(ops: &[Op], path: &Path) -> std::io::Result<()> {
         rec[32..40].copy_from_slice(&op.c_target.0.to_le_bytes());
         rec[40..48].copy_from_slice(&op.c_condition.0.to_le_bytes());
         rec[48..56].copy_from_slice(&op.r_target.0.to_le_bytes());
-        w.write_all(&rec)?;
+        enc.write_all(&rec)?;
     }
+    let mut w = enc.finish()?;
     w.flush()?;
     drop(w);
     fs::rename(&tmp, path)?;
@@ -61,10 +80,14 @@ fn main() {
         eprintln!("error: failed to write {}: {}", OPS_PATH, e);
         std::process::exit(2);
     }
+    let uncompressed = ops.len() * OP_BYTES + MAGIC.len() + 8;
+    let on_disk = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
     println!(
-        "  wrote       : {} ({} bytes)",
+        "  wrote       : {} ({} bytes on disk, {} uncompressed, {:.1}x)",
         OPS_PATH,
-        ops.len() * OP_BYTES + MAGIC.len() + 8
+        on_disk,
+        uncompressed,
+        uncompressed as f64 / on_disk.max(1) as f64,
     );
     println!("\n=== build_circuit OK ===");
 }

--- a/src/bin/eval_circuit.rs
+++ b/src/bin/eval_circuit.rs
@@ -20,13 +20,20 @@ use sha3::{
     digest::{ExtendableOutput, Update, XofReader},
     Shake256,
 };
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, Read, Write};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const OPS_PATH: &str = "ops.bin";
-const MAGIC: &[u8; 8] = b"QECCOPS1";
+// "Z" framing: 16-byte plaintext header (MAGIC + u64 count) then a zstd
+// frame of the fixed-width records. The count is read before decompressing
+// so we can bound memory, and we read exactly count*OP_BYTES bytes out of
+// the decoder so a crafted frame cannot expand without bound.
+const MAGIC: &[u8; 8] = b"QECCOPSZ";
+// Cap the zstd window the decoder will accept (2^27 = 128 MiB). A forged
+// ops.bin cannot force a huge decompression-window allocation.
+const ZSTD_WINDOW_LOG_MAX: u32 = 27;
 const FIELD_BYTES: usize = 8;
 const OP_FIELDS: usize = 7;
 const OP_BYTES: usize = OP_FIELDS * FIELD_BYTES;
@@ -87,38 +94,45 @@ fn read_u64(bytes: &[u8], off: usize) -> u64 {
 }
 
 fn load_ops(path: &str) -> Result<Vec<Op>, String> {
-    let bytes = fs::read(path).map_err(|e| format!("read {path}: {e}"))?;
-    if bytes.len() < MAGIC.len() + 8 {
-        return Err(format!("{path}: too short ({} bytes)", bytes.len()));
-    }
-    if &bytes[..MAGIC.len()] != MAGIC {
+    let mut file = File::open(path).map_err(|e| format!("open {path}: {e}"))?;
+
+    // Plaintext header: MAGIC + u64 op count. Read and validate before
+    // decompressing so the op count bounds every allocation below.
+    let mut header = [0u8; MAGIC.len() + 8];
+    file.read_exact(&mut header)
+        .map_err(|e| format!("{path}: too short to read header: {e}"))?;
+    if &header[..MAGIC.len()] != MAGIC {
         return Err(format!("{path}: bad magic"));
     }
-    let n = u64::from_le_bytes(bytes[MAGIC.len()..MAGIC.len() + 8].try_into().unwrap());
+    let n = u64::from_le_bytes(header[MAGIC.len()..].try_into().unwrap());
     if n > MAX_OPS {
         return Err(format!("{path}: op count {n} exceeds cap {MAX_OPS}"));
     }
     let n = n as usize;
-    let need = MAGIC.len() + 8 + n.saturating_mul(OP_BYTES);
-    if bytes.len() != need {
-        return Err(format!(
-            "{path}: length mismatch: got {} expected {need} for {n} ops",
-            bytes.len()
-        ));
-    }
+
+    // Stream-decompress the record body. We read exactly n * OP_BYTES bytes
+    // out of the decoder, so a forged frame cannot expand without bound; the
+    // window cap limits the decoder's own buffer allocation.
+    let mut dec = zstd::stream::read::Decoder::new(BufReader::new(file))
+        .map_err(|e| format!("{path}: zstd init: {e}"))?;
+    dec.window_log_max(ZSTD_WINDOW_LOG_MAX)
+        .map_err(|e| format!("{path}: zstd window cap: {e}"))?;
+
     let mut ops = Vec::with_capacity(n);
-    let mut off = MAGIC.len() + 8;
+    let mut rec = [0u8; OP_BYTES];
     for i in 0..n {
-        let kind_raw = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+        dec.read_exact(&mut rec)
+            .map_err(|e| format!("op {i}: short read from compressed body: {e}"))?;
+        let kind_raw = u32::from_le_bytes(rec[0..4].try_into().unwrap());
         let kind = op_kind_from_u32(kind_raw)
             .ok_or_else(|| format!("op {i}: unknown kind {kind_raw}"))?;
-        // bytes[off+4..off+8] are reserved padding for 8-byte alignment.
-        let q_control2 = QubitId(read_u64(&bytes, off + 8));
-        let q_control1 = QubitId(read_u64(&bytes, off + 16));
-        let q_target = QubitId(read_u64(&bytes, off + 24));
-        let c_target = BitId(read_u64(&bytes, off + 32));
-        let c_condition = BitId(read_u64(&bytes, off + 40));
-        let r_target = RegisterId(read_u64(&bytes, off + 48));
+        // rec[4..8] are reserved padding for 8-byte alignment.
+        let q_control2 = QubitId(read_u64(&rec, 8));
+        let q_control1 = QubitId(read_u64(&rec, 16));
+        let q_target = QubitId(read_u64(&rec, 24));
+        let c_target = BitId(read_u64(&rec, 32));
+        let c_condition = BitId(read_u64(&rec, 40));
+        let r_target = RegisterId(read_u64(&rec, 48));
 
         let op = Op {
             kind,
@@ -141,7 +155,14 @@ fn load_ops(path: &str) -> Result<Vec<Op>, String> {
             return Err(format!("op {i}: {msg}"));
         }
         ops.push(op);
-        off += OP_BYTES;
+    }
+
+    // Reject trailing data: exactly n records must decompress, no more.
+    let mut extra = [0u8; 1];
+    match dec.read(&mut extra) {
+        Ok(0) => {}
+        Ok(_) => return Err(format!("{path}: trailing data after {n} ops")),
+        Err(e) => return Err(format!("{path}: error checking for trailing data: {e}")),
     }
     Ok(ops)
 }
@@ -226,8 +247,9 @@ fn run_tests(
     let mut expected = Vec::with_capacity(target_shots);
     for _ in 0..target_shots {
         let mut rb = [[0u8; 32]; 2];
-        xof.read(&mut rb[0]);
-        xof.read(&mut rb[1]);
+        // Disambiguate from std::io::Read (in scope for the zstd loader).
+        XofReader::read(&mut xof, &mut rb[0]);
+        XofReader::read(&mut xof, &mut rb[1]);
         let k1 = U256::from_le_bytes(rb[0]);
         let k2 = U256::from_le_bytes(rb[1]);
         let t = curve.mul(curve.gx, curve.gy, k1);


### PR DESCRIPTION
updating the harness to be more friendly to low qubit (gigantic toffoli) submissions in a way that works with the server infra. Changes:

- writing ops.bin is done in a streaming to file fashion to not double memory allocation during circuit building
- circuit is compressed before being written to ops.bin to prevent huge files on disk