### PR TITLE
Run production benchmark on Blacksmith

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,132 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark on 128 GB runner
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 360
+    outputs:
+      score: ${{ steps.score.outputs.value }}
+
+    steps:
+      - name: Checkout dispatched commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+
+      # Yukon enforces editablePaths while constructing the commit. Keep this
+      # independent check so a malformed submissions/* ref fails before setup.
+      - name: Verify submission surface
+        if: startsWith(github.ref, 'refs/heads/submissions/')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read -r -a commit_line <<< "$(git rev-list --parents -n 1 "$GITHUB_SHA")"
+          if (( ${#commit_line[@]} != 2 )); then
+            echo "Submission must be a single-parent commit" >&2
+            exit 1
+          fi
+
+          while IFS= read -r -d '' changed_path; do
+            case "$changed_path" in
+              src/point_add|src/point_add/*) ;;
+              *)
+                echo "Submission changed a non-editable path: $changed_path" >&2
+                exit 1
+                ;;
+            esac
+          done < <(git diff --no-renames --name-only -z "$GITHUB_SHA^" "$GITHUB_SHA")
+
+      - name: Verify runner capacity
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$(uname -s)" == "Linux" ]]
+          [[ "$(uname -m)" == "x86_64" ]]
+          command -v jq >/dev/null
+
+          mem_kib=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
+          min_mem_kib=$((120 * 1024 * 1024))
+          if (( mem_kib < min_mem_kib )); then
+            echo "Runner has less than 120 GiB usable RAM" >&2
+            exit 1
+          fi
+
+          min_disk_kib=$((160 * 1024 * 1024))
+          for disk_path in "$GITHUB_WORKSPACE" /tmp; do
+            free_disk_kib=$(df -Pk "$disk_path" | awk 'NR == 2 { print $4 }')
+            if (( free_disk_kib < min_disk_kib )); then
+              echo "Runner has less than 160 GiB free at $disk_path" >&2
+              exit 1
+            fi
+          done
+
+      - name: Restore setup cache
+        id: setup-cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ecadd-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain*') }}
+
+      - name: Setup
+        shell: bash
+        run: ./setup.sh
+
+      # Submission refs can restore the default branch's cache, but never save
+      # one. Warm a new cache by manually dispatching this workflow on main.
+      - name: Save setup cache
+        if: github.ref_name == github.event.repository.default_branch && steps.setup-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ steps.setup-cache.outputs.cache-primary-key }}
+
+      - name: Benchmark
+        shell: bash
+        run: ./benchmark.sh
+
+      - name: Report score
+        id: score
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          score=$(jq -er '.score | select(type == "number")' score.json)
+          echo "value=$score" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Benchmark score"
+            echo
+            echo "\`$score\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Benchmark score: $score"
+
+      - name: Upload score
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: benchmark-score
+          path: score.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
   benchmark:
     name: Benchmark on 128 GB runner
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 360
+    timeout-minutes: 45
     outputs:
       score: ${{ steps.score.outputs.value }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,31 +52,6 @@ jobs:
             esac
           done < <(git diff --no-renames --name-only -z "$GITHUB_SHA^" "$GITHUB_SHA")
 
-      - name: Verify runner capacity
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          [[ "$(uname -s)" == "Linux" ]]
-          [[ "$(uname -m)" == "x86_64" ]]
-          command -v jq >/dev/null
-
-          mem_kib=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
-          min_mem_kib=$((120 * 1024 * 1024))
-          if (( mem_kib < min_mem_kib )); then
-            echo "Runner has less than 120 GiB usable RAM" >&2
-            exit 1
-          fi
-
-          min_disk_kib=$((160 * 1024 * 1024))
-          for disk_path in "$GITHUB_WORKSPACE" /tmp; do
-            free_disk_kib=$(df -Pk "$disk_path" | awk 'NR == 2 { print $4 }')
-            if (( free_disk_kib < min_disk_kib )); then
-              echo "Runner has less than 160 GiB free at $disk_path" >&2
-              exit 1
-            fi
-          done
-
       - name: Restore setup cache
         id: setup-cache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Benchmark on 128 GB runner
+    name: Benchmark
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
     outputs:
@@ -89,13 +89,21 @@ jobs:
           set -euo pipefail
 
           score=$(jq -er '.score | select(type == "number")' score.json)
+          toffoli=$(jq -er '.metrics.toffoli | select(type == "number")' score.json)
+          qubits=$(jq -er '.metrics.qubits | select(type == "number")' score.json)
           echo "value=$score" >> "$GITHUB_OUTPUT"
           {
-            echo "## Benchmark score"
+            echo "## Benchmark results"
             echo
-            echo "\`$score\`"
+            echo "| Metric | Value |"
+            echo "| --- | ---: |"
+            echo "| Score | \`$score\` |"
+            echo "| Toffoli | \`$toffoli\` |"
+            echo "| Qubits | \`$qubits\` |"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Benchmark score: $score"
+          echo "Toffoli: $toffoli"
+          echo "Qubits: $qubits"
 
       - name: Upload score
         if: always()

--- a/benchmark.json
+++ b/benchmark.json
@@ -7,5 +7,9 @@
   "editablePaths": ["src/point_add"],
   "setupCommand": ["bash", "-lc", "./setup.sh"],
   "benchmarkCommand": ["bash", "-lc", "./benchmark.sh"],
-  "scorePath": "score.json"
+  "scorePath": "score.json",
+  "runner": {
+    "provider": "github-actions",
+    "workflow": "benchmark.yml"
+  }
 }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -120,7 +120,7 @@ build_circuit_bin="$(pwd)/target/release/build_circuit"
 #    the trusted eval_circuit binary, or the repo sources, and from reaching the
 #    network — none of which the process-group reap below covers at run time.
 ops_scratch="$(cd "$(mktemp -d)" && pwd -P)"   # resolved real path (the macOS profile needs it)
-chmod 0777 "${ops_scratch}"   # the unprivileged sandbox uid must be able to write here
+chmod 1777 "${ops_scratch}"   # let the sandbox uid write without replacing runner-owned files
 
 # Build the (possibly confined) invocation:
 #   - Linux: bubblewrap (installed by setup.sh in the trusted sandbox).
@@ -129,6 +129,14 @@ chmod 0777 "${ops_scratch}"   # the unprivileged sandbox uid must be able to wri
 #     scores in a sandbox, so this never applies to the official run).
 bwrap_via_sudo=0
 if command -v bwrap >/dev/null 2>&1; then
+  # Blacksmith keeps /home/runner private from other users. Once bwrap drops to
+  # uid 65534, executing the binary through its workspace path therefore fails
+  # even though the file itself is executable. Stage a read-only copy in the
+  # world-traversable scratch directory that is already mounted into the sandbox.
+  sandbox_build_circuit_bin="${ops_scratch}/build_circuit"
+  cp "${build_circuit_bin}" "${sandbox_build_circuit_bin}"
+  chmod 0555 "${sandbox_build_circuit_bin}"
+
   # The sandbox runs this as a non-root user, and its bwrap carries Linux file
   # capabilities without setuid — which bwrap refuses when run non-root
   # ("Unexpected capabilities but not setuid, old file caps config?"). Get bwrap
@@ -154,7 +162,7 @@ if command -v bwrap >/dev/null 2>&1; then
       --unshare-user --unshare-net --unshare-ipc --unshare-uts --unshare-cgroup
       --cap-drop ALL --new-session --die-with-parent
       --uid 65534 --gid 65534
-      -- "${build_circuit_bin}"
+      -- "${sandbox_build_circuit_bin}"
   )
 elif [[ "$(uname -s)" == "Darwin" ]] && command -v sandbox-exec >/dev/null 2>&1; then
   # Read-only everywhere except the scratch dir (and /dev), and no network. TMPDIR


### PR DESCRIPTION
## Summary
- route Yukon benchmark execution through `benchmark.yml`
- use the Blacksmith 32-vCPU Ubuntu 24.04 runner with a 45-minute timeout
- restore/save the trusted setup cache and upload `score.json`
- report score, Toffoli count, and qubit count in the job summary
- stage `build_circuit` in accessible scratch space before bubblewrap drops privileges

## Cherry-picked from quantum_ecc_add
- `0ac1102` Run benchmark on Blacksmith
- `77e47e1` Remove runner capacity preflight
- `56c7b8c` Limit benchmark workflow to 45 minutes
- `ab01e00` Run sandboxed circuit from accessible scratch path
- `55bee93` Improve the benchmark summary

The same workflow passed on Blacksmith in https://github.com/Layr-Labs/quantum_ecc_add/actions/runs/30851354316.

## Validation
- `actionlint -ignore 'label "blacksmith-32vcpu-ubuntu-2404" is unknown' .github/workflows/benchmark.yml`
- `shellcheck -e SC2016 benchmark.sh setup.sh`
- `bash -n benchmark.sh setup.sh`
- validated the GitHub Actions runner block in `benchmark.json`
- confirmed the workflow is byte-for-byte identical to the tested source workflow
- `git diff --check main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/ecdsafail-challenge/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788390667&installation_model_id=21733&pr_number=17&repository=Layr-Labs%2Fecdsafail-challenge&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fecdsafail-challenge%2Fpull%2F17&signature=421fbd7892baf083d7bfc9c7818b0b06a3f1ffdc433858120702757f80866cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->