### PR TITLE
memory: syntactic certification is exhausted, with controls

### DIFF
--- a/src/point_add/memory/07-syntactic-certification.md
+++ b/src/point_add/memory/07-syntactic-certification.md
@@ -1,0 +1,264 @@
+# Syntactic certification — three closed approaches, three passing controls
+
+Sections 1 and 3 are measured on the certified frontier `cf5aa02` — the promoted source of submission
+`0c5b1b7b-561a-48a0-abc6-5fefaffdc0ad`, score **`1,490,805,286`**. Section 2 was measured on `6909d15`
+(score `1,486,468,554`) and has **not** been re-measured here; it says so where its numbers appear. Every
+conclusion below was checked on both heads and none differs — only counts.
+
+The §1 instrument independently reproduces four entries of `06-research-status.md`'s certified table, which is
+what licenses the rest:
+
+| quantity | `06-research-status.md` | [`repro/hotness.rs`](repro/hotness.rs) on `cf5aa02` |
+|---|---:|---:|
+| average executed Toffoli | `1,291,859.302` | `1,291,859.302` |
+| total executed Toffoli | `11,657,738,337` | `11,657,738,337` |
+| emitted operations | `9,062,420` | `9,062,420` |
+| qubits | `1,154` | `1,154` |
+
+Status vocabulary is `06-research-status.md`'s. All three results below are **Established** within their stated
+class: each is a structural argument or an exact enumeration, not a search that ran out of time.
+
+## The target
+
+**46,286 CCX/CCZ — 3.35% of the score, 43,237.5 avgT — fire on none of the 9,024 official shots.** The
+strict-beat bar is **0.802 avgT** (the frontier is `1,291,859 × 1154`, so `round(avgT) <= 1,291,858` scores
+`1,490,804,132` and wins by 1,154 points), so *one* certified gate is a submission.
+
+The obstacle is `04-traps.md` §1, in its sharpest form: the 9,024 test inputs are a SHAKE256 hash of the whole op
+stream (`eval_circuit.rs:204`). Deleting a gate re-rolls every shot. "Never fired on this draw" is a certificate
+that cannot survive its own use. Only a stream-agnostic certificate is shippable.
+
+Three ways to get one were tried. All three are closed, and they close for the same reason.
+
+## Why each negative carries a control
+
+A search that finds nothing is indistinguishable from a search that cannot see. Every negative below is paired
+with a known-answer or planted-signal control. **Two of the three controls fired before the negative was
+believed**, which is the only reason the negatives are stated as results rather than as absences.
+
+---
+
+## 1. Cooling — making gates conditionally cold — CLOSED, class empty
+
+The scorer bills a Toffoli by `popcount` of its condition mask and ignores the control qubits (`src/sim.rs:77-86`).
+So a gate charged on fewer shots costs less **whether or not it ever fires**. Tighten condition stacks, harvest the
+difference. The mechanism is real and correctly stated in `CEILING.md`.
+
+**Control (known-answer).** [`repro/hotness.rs`](repro/hotness.rs) replays the official measurement — `build()`,
+`analyze_ops`, the Fiat–Shamir XOF over the whole stream, the same 9,024-shot draw, the same 64-shot batching —
+with `apply_iter` copied dispatch-for-dispatch and one line added to attribute `executed_shots` to the op that
+incurred it. It asserts reconstruction of the scorer's own total:
+
+```
+GATE ok: attributed=11657738337 == toffoli_gates=11657738337
+avgT=1291859.302        (06-research-status.md certifies 1,291,859.302)
+```
+
+**This control fired.** A first run drew 9,216 shots instead of 9,024 and gave `avgT=1288114.585` — plausible to
+the eye, and wrong. Nothing downstream is meaningful without the `GATE ok` line.
+
+**Result.** 1,347,438 CCX/CCZ, 9,024 shots, total charge 11,657,738,337.
+
+| band | gates | share of gates | share of charge |
+|---|---:|---:|---:|
+| cold (hotness 0) | **0** | 0.000% | 0.000% |
+| partial, all in `[0.4798, 0.5186]` | 111,162 | 8.250% | 4.303% |
+| full (hotness exactly 1.0) | 1,236,276 | 91.750% | 95.697% |
+
+**No gate is charged on fewer than 4,330 of 9,024 shots.** The hotness distribution is bimodal at 1.0 and 0.5 with
+nothing anywhere else — the decile histogram is empty outside buckets 4, 5 and 10. The partial band's mean is
+0.5000 and its ±0.02 spread is sampling noise on 9,024 draws.
+
+The 0.5 band is a fair coin, and that is structural. **Every CCX/CCZ in the stream has `c_condition = NO_BIT`** —
+one distinct condition-bit value across all 1.35 M gates. All conditioning therefore comes from the enclosing
+`PushCondition` blocks, and the bits those push are `Hmr` measurement outcomes, which are independent of the
+quantum controls. Firing is a function of the controls; the condition is a classical bit that cannot see them.
+The probability that a given gate's ~2,256 firing shots all land inside a given fair coin's 4,512 true shots is
+**2⁻²²⁵⁶ ≈ 10⁻⁶⁷⁹**. Manufacturing the bit instead means measuring the controls — an `Hmr`, which destroys the
+qubit — to save at most 0.75 of one Toffoli.
+
+Pricing the lever with a perfect oracle condition granted to all 1,347,438 gates at once: `charge − fire` summed
+over the stream is **8,946,656,859 shot-charges = 991,429 avgT = 76.74% of the score** (only 23.26% of charge is
+on a shot where the gate fires). Enormous, and unreachable for the reason above. The fire rate concentrates at
+**0.25** — exactly the rate at which a Toffoli with two independent uniform controls fires — with **60.2%** of
+unconditional gates in `[0.20, 0.30)`. Those gates are not wasteful. Three quarters of a Toffoli's charge is the
+price of the shots where its controls are not both 1.
+
+**The candidate class is empty for a structural reason, not a failed search.** Do not re-mine it.
+
+---
+
+## 2. Per-shot census sampling — CLOSED, cannot certify the target
+
+Sample inputs, retain the per-shot effect mask per gate, and certify dead any gate that never fires. This is what
+`census.rs` and the shipped `deep_strip_keys.rs` do.
+
+**Control (known-answer).** Replaying the occupancy tripwire (`04-traps.md` §2) against a per-gate dump reproduces
+`build_circuit`'s own accept/discard counts, which is what makes the keying — as opposed to the predicates —
+provably correct.
+
+**This control also fired**, in the useful direction: it isolated the discrepancy to the certification predicates
+rather than to the addressing. On the table it was run against, of the shipped keys the tripwire accepts —
+applied in a circuit that passes `9,024/9,024` — the census claims **3,076 dead keys fire (25.02%)** and
+**1,674 downgrades violated (42.67%)**. The shipped table demonstrably yields 0/0/0. The census over-observes.
+
+> **Provenance — this section was measured on `6909d15`, not on `cf5aa02`.** Its counts (dead 12,292 accepted /
+> 251 stale, downgrade 3,923 / 0) are from a re-mined table of 16,466 keys, and are a third table again: `cf5aa02`
+> emits **13,831 keys** and reports
+> `[deep-strip-identity] removed 10743 / 10743 dead; downgraded 3088 / 3088 to CX/CZ; 0 stale keys skipped`,
+> while `6909d15` emits 17,278. Neither frontier build reports a single stale key. The 25.02% / 42.67% figures
+> therefore do **not** reproduce from `cf5aa02` without re-running the miner, and should be read as the magnitude
+> of a measured disagreement, not as a property of the shipped table. The mechanism below does not depend on
+> which table is used.
+
+**Result.** The approach cannot certify any of the 46,286, and the reason is definitional rather than
+quantitative. A sampler observes *firing*. It has no access to *why* a gate does not fire. If a gate is quiet
+because of a data invariant — a theorem about what the registers can hold — the census cannot represent that and
+can only report an empirical rate at whatever depth it ran. Two censuses at different depths, or over different
+input distributions, then disagree about exactly the rarest-firing gates, which is the population in dispute.
+"Never fired on this draw" is a statement about one draw, and any edit re-rolls all 9,024 inputs.
+
+This is the same monotonicity `03-proven-floors.md` records under *Dead-gate census — OVER-drawn, not dry*: at
+1e9 inputs only 1,290 of 1,442 shipped keys were still never-firing and 153 shipped keys fire. That section states
+the depth-dependence as an observation; this section states its mechanism. **A 25%/43% disagreement between two
+censuses is not a miner bug and not a defect in the shipped table — it is the signature of certifying by
+observation something that is true by invariant.**
+
+> **Scope.** `06-research-status.md`'s open problems are exact-eight joint synthesis, the controlled-addition
+> factor-two gap, the streaming dialog ranker, new source implications, and low-qubit representation pricing. It
+> does not list a census over-observation gap, and the shipped table works. The overlap is that its *Deep-strip
+> localization* row concludes transfer failures originate upstream rather than in the final table — consistent
+> with this, and a different claim. The gap resolved here is this fork's, carried in its own census-miner notes.
+
+---
+
+## 3. Affine-relation analysis over GF(2) — CLOSED, no relation exists
+
+A `CCX` never fires if `q(c1) & q(c2) = 0` identically. Two syntactic cases decide that without knowing values: a
+control is constant 0, or the controls are complementary (`c1 = ¬c2`). Complementary flag pairs are what binary-GCD
+sign and branch logic ought to produce.
+
+Two rungs. `constzero.rs` is a three-valued constant lattice. `affine.rs` carries a full affine form per qubit
+(`constant XOR (XOR of atoms)`, atoms XOR-hashed into a `u128`), with `X`/`CX`/`Swap`/`R`/`Hmr` propagating exactly
+under provably-`AllOnes` conditions, and `CCX` targets taking a **hash-consed AND term** keyed on the control forms
+— an XOR-of-AND graph in which identical subexpressions collapse rather than degrading to opaque unknowns.
+
+**Control (planted signal).** `affine.rs --positive-control` builds a stream where `CX(q0→q1); X(q1)` makes
+`q1 = ¬q0`, places a `CCX(q1,q0,q2)` and a `CCZ(q1,q0,q5)` on that complementary pair, and a `CCX(q3,q0,q4)` on
+unrelated controls:
+
+```
+CERTIFIED never-firing gates : 2
+  op 2 kind 13 reason c1=!c2
+  op 4 kind 14 reason c1=!c2
+POSITIVE CONTROL PASS
+```
+
+Both planted pairs detected, the unrelated gate correctly not certified. `constzero.rs` carries matching
+non-vacuity evidence: **6,298,889** ops tracked under provably-`AllOnes` conditions (against 2,757,267 Mixed), and
+a Zero population moving 67 → 54 → 341 → 598 across four checkpoints as ancillas are allocated and uncomputed.
+
+**Result: zero gates certified, by either rung.**
+
+| diagnostic | value |
+|---|---:|
+| CCX total | 1,342,695 |
+| atoms minted | 2,999,976 |
+| CCX with a constant-1 control | **0** |
+| CCX with equal controls | **0** |
+| distinct AND terms | 1,229,522 |
+| — recovered by hash-consing | 6,754 |
+| CCX/CCZ whose controls share a single atom | **0** |
+| certified | **0** |
+
+**Not one gate in the circuit has controls that are affinely related at all** — not equal, not complementary, not
+even sharing one atom. Hash-consing collapses 6,754 of 1,342,695 terms; the remaining 1.23 M nonlinear terms are
+genuinely distinct subexpressions, so the zero is a property of the circuit and not an analyzer that gave up. The
+constant rung agrees from the other side: all 1,347,438 CCX/CCZ have **both** controls Unknown, and not one has a
+provably-One control.
+
+Both rungs `--check` clean against the `cf5aa02` hotness dump — 0 certified, 0 violations — leaving
+**46,286 never-firing gates, 0 explained structurally, 46,286 still unexplained.**
+
+The constant rung's zero has its own explanation: `build()` already runs CONSTPROP (`dropped=282, folded_cx=23,
+aff_drop=9`), so that certificate class was emptied before the stream was final.
+
+**The complementary-flag intuition is not borne out.**
+
+---
+
+## The unifying finding
+
+All three approaches reason about the **form** of a value.
+
+| approach | what it inspects | why it fails here |
+|---|---|---|
+| cooling | which classical bit gates the charge | firing is quantum; the classical bits are independent coins |
+| census | the empirical fire rate at depth N | an invariant is not visible in a sample at any depth |
+| affine | the algebraic expression for each wire | 1.23 M distinct nonlinear terms, no two controls related |
+
+**This circuit computes modular inversion and modular multiplication.** Nearly every value is a nonlinear function
+of the inputs, so there is no exploitable form to inspect. Affine structure survives only through `CX`/`X` chains
+uninterrupted by any `CCX`, and no such chain reaches any gate's control pair. The 46,286 gates are quiet because
+of **what their controls can be**, not because of how those controls are written or how often they were watched.
+
+One sentence covering three separate negatives, and it is the substantive result: the cheap certification routes
+are not merely unproductive, they are **the wrong kind of argument**. A sampler cannot see an invariant. The
+46,286 are not low-hanging.
+
+## What would certify one
+
+A **semantic** argument over the data invariants of the binary-GCD engine — register bit ranges, mutual exclusion
+of branch flags, the loop invariant relating `u`, `v` and the schedule width. The tractable shape:
+
+1. encode **one divstep** as a transition relation (the engine is a loop, so one step is small);
+2. discharge the candidate invariant over that step with a bounded model checker or an SMT solver;
+3. lift by induction over the 261 divsteps;
+4. a gate whose control pair the invariant excludes is then certified for **all** inputs — stream-agnostic,
+   λ-free, safe to delete.
+
+This is also the only route that closes the census disagreement from the other side, since the same invariant is
+what the sampler cannot see. Research-scale rather than overnight, and now the only identified route from the
+46,286 to a submission.
+
+## Standing
+
+Nothing was removed and no configuration beating `1,490,805,286` was produced. Deleting any of the 46,286 on
+9,024-shot evidence is exactly the stream-specificity error `04-traps.md` §1 documents. **Prove before removing** —
+none of these three approaches proved anything.
+
+## Reproducing
+
+`hotness.rs` is retained as [`repro/hotness.rs`](repro/hotness.rs) because it carries §1 and the 46,286 count.
+There is no `[[example]]` entry in `Cargo.toml`, so it is built the way `hyperplane_mitm.cpp` is — copied out,
+compiled, scratch directory removed. From the repository root:
+
+```sh
+mkdir -p examples && cp src/point_add/memory/repro/hotness.rs examples/
+cargo build --release --offline --example hotness
+./target/release/examples/hotness -            # summary only
+./target/release/examples/hotness /tmp/head    # also writes /tmp/head.hot.tsv, one row per gate
+rm -rf examples
+```
+
+**Check the `GATE ok` line and that `avgT` matches `eval_circuit` before reading anything else** — the instrument
+is meaningless unless it reconstructs the scorer's total, and the assertion is what caught the 9,216-shot draw.
+It honours `SUB4_APPLY_STRIP` / `TLM_SCHED_J2_DELTA`, so run it under the same environment as the build being
+priced. Verified on `cf5aa02` at 29 s build / 53 s run, reproducing every §1 figure above and four entries of
+`06-research-status.md`'s certified table.
+
+The two §3 rungs are not retained here, but they need no patching: `constzero.rs` and `affine.rs` compile and run
+against an unmodified `cf5aa02` checkout exactly as `hotness.rs` does. Fetch them from
+[`austinamissah/ecdsa-circuit-optimization`](https://github.com/austinamissah/ecdsa-circuit-optimization)
+`tools/census/` at commit `ff5d6e0`, drop them in the same `examples/`, and:
+
+```sh
+cargo build --release --offline --example affine --example constzero
+./target/release/examples/affine    --positive-control     # must print POSITIVE CONTROL PASS
+./target/release/examples/constzero --check /tmp/head.hot.tsv
+./target/release/examples/affine    --check /tmp/head.hot.tsv
+```
+
+Run the positive control first. Every `--check` requires that no certified gate fired on any of the 9,024 shots
+and exits non-zero otherwise; both exit 0 on `cf5aa02` with 0 certified and 0 violations. The §2 census is the one
+piece not reproducible from this tree — it needs fork-local mining infrastructure.

--- a/src/point_add/memory/07-syntactic-certification.md
+++ b/src/point_add/memory/07-syntactic-certification.md
@@ -5,6 +5,19 @@ Sections 1 and 3 are measured on the certified frontier `cf5aa02` — the promot
 (score `1,486,468,554`) and has **not** been re-measured here; it says so where its numbers appear. Every
 conclusion below was checked on both heads and none differs — only counts.
 
+**Scope note, added 2026-08-23.** The counts here are measured on the 1,154-qubit trailmix/dialog
+construction, which is now legacy and gated behind `SUB4_LEGACY_POINT_ADD`; the shipping path is
+`pingpong_div.rs` at 1,278 qubits. Treat the specific figures below (46,286 dead CCX, the score
+targets, the qubit counts) as a record of that circuit.
+
+The central argument is not construction-specific and still holds. The 9,024 test inputs are a
+SHAKE256 hash of the whole op stream, so any edit that changes the stream re-rolls every shot, and
+"never fired on this draw" cannot survive its own use. That was re-confirmed independently on the
+ping-pong construction on 2026-08-23: its width schedule carries 800 to 1,693 bit-rounds of unused
+slack, worth roughly 8,000 Toffoli at the measured 4.7 to 4.9 Toffoli per bit-round, and none of it
+is collectable. Tightening the schedule to a draw's own envelope changes the op stream, which
+re-rolls the draw the tightening was justified by. Same obstacle, different construction.
+
 The §1 instrument independently reproduces four entries of `06-research-status.md`'s certified table, which is
 what licenses the rest:
 

--- a/src/point_add/memory/README.md
+++ b/src/point_add/memory/README.md
@@ -11,8 +11,10 @@ re-entry commands. These notes live under `src/point_add` so they travel with su
 | `04-traps.md` | four ways an env knob silently no-ops, positional addressing, validation gates |
 | `05-qubit-reduction.md` | the measured qubit programme, including the exchange-rate trap |
 | `06-research-status.md` | latest research handoff: certified baseline, scoped results, counterexamples, unresolved work, re-entry conditions |
+| `07-syntactic-certification.md` | three closed routes to a stream-agnostic dead-gate certificate, each with a passing control; why the 46,286 never-firing gates need a semantic argument |
 | `repro/` | compact tested programs retained to reproduce or extend the durable claims |
 | [`repro/world_model.py`](repro/world_model.py) | executable evidence, invalidation, history-replay, and promotion-gate model |
+| [`repro/hotness.rs`](repro/hotness.rs) | per-gate charge/fire census; self-gating — aborts unless it reconstructs the scorer's own Toffoli total |
 
 The single most important operational fact: **a persistent-set reduction only pays if you lower `TLM_TARGET_Q` by the
 same amount**, because the vent pool expands to fill whatever you free. The second most important: **only a

--- a/src/point_add/memory/repro/hotness.rs
+++ b/src/point_add/memory/repro/hotness.rs
@@ -1,0 +1,512 @@
+//! Per-gate **hotness** census: for every CCX/CCZ in the scored stream, the number
+//! of the 9,024 official shots on which its classical condition stack is satisfied.
+//!
+//! ## Why this is the quantity that matters
+//!
+//! The scorer charges a Toffoli by the popcount of its condition mask, and by
+//! nothing else (`src/sim.rs:77-86`, verbatim):
+//!
+//! ```text
+//! let mut cond = current_base_condition;                       // PushCondition stack
+//! if op.c_condition != NO_BIT { cond &= self.bit(op.c_condition); }
+//! let executed_shots = cond.count_ones() as u64;
+//! match op.kind {
+//!     OperationType::CCZ | OperationType::CCX => {
+//!         self.stats.toffoli_gates += executed_shots;
+//!     }
+//! ```
+//!
+//! The charge does **not** depend on the control qubits. So a gate is charged in
+//! full even when its controls make it a no-op, and a gate whose condition stack
+//! is false on a shot is free on that shot. `score = round(total/9024) x Q`.
+//!
+//! That splits the cost surface into two independent levers, only one of which
+//! the deep strip addresses:
+//!
+//!   - **delete** a gate: needs a proof it never *fires* (effect mask always zero).
+//!     That is what a fire-census certifies, and it is expensive to establish and
+//!     fragile under stream edits. See `../07-syntactic-certification.md` for why
+//!     the sampled version of that proof cannot be made stream-agnostic.
+//!   - **cool** a gate: tighten its condition stack so it is charged on fewer
+//!     shots. Semantics are preserved for free whenever the added condition is
+//!     implied by the existing one on every shot where the gate can fire.
+//!
+//! A gate at hotness h costs exactly h Toffoli-shots. Cooling a gate from h to h'
+//! saves (h - h')/9024 of average Toffoli, whether or not it ever fires.
+//!
+//! ## Method
+//!
+//! This replays the **official** measurement: `point_add::build()`, `analyze_ops`
+//! for the register layout, the Fiat-Shamir XOF over the whole op stream, the same
+//! 9,024-shot draw, the same 64-shot batching, and the condition/dispatch loop
+//! copied verbatim from `src/sim.rs::apply_iter` with one line added to attribute
+//! `executed_shots` to the op that incurred it.
+//!
+//! **Gate on the instrument.** Nothing here is trustworthy unless the attributed
+//! charges sum to the scorer's own total. The tool asserts
+//! `sum(charge) == sim.stats.toffoli_gates` and prints avgT so it can be checked
+//! against `eval_circuit` by eye. Run it on a circuit you have just scored.
+//!
+//! ## Usage
+//!
+//! There is no `[[example]]` entry in `Cargo.toml`, so this is built the same way
+//! `hyperplane_mitm.cpp` is: copied out, compiled, and the scratch directory removed.
+//! Run from the repository root.
+//!
+//!     mkdir -p examples && cp src/point_add/memory/repro/hotness.rs examples/
+//!     cargo build --release --offline --example hotness
+//!     ./target/release/examples/hotness out        # writes out.hot.tsv
+//!     ./target/release/examples/hotness -          # summary only, no files
+//!     rm -rf examples
+//!
+//! Honours `SUB4_APPLY_STRIP` / `TLM_SCHED_J2_DELTA` like every other instrument;
+//! run it with the same environment as the build you are pricing. Default (no env)
+//! is the scored circuit.
+//!
+//! Output `<prefix>.hot.tsv`, one line per CCX/CCZ in stream order:
+//!     opidx  kind  c2  c1  t  cond  charge  fire  head  hotness
+//! where `charge` is shots-charged out of `n_shots`, `fire` is shots on which the
+//! effect mask is non-zero, `head = charge - fire` is the per-gate cooling ceiling,
+//! and `hotness = charge/n_shots`.
+
+use quantum_ecc::circuit::{analyze_ops, BitId, Op, OperationType, QubitId, QubitOrBit, NO_BIT};
+use quantum_ecc::point_add;
+use quantum_ecc::sim::Simulator;
+use quantum_ecc::weierstrass_elliptic_curve::WeierstrassEllipticCurve;
+use ruint::aliases::U256;
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::Shake256;
+use std::collections::HashMap;
+use std::io::Write;
+
+const NUM_TESTS: usize = 9024;
+const BATCH: usize = 64;
+
+// Verbatim from src/bin/eval_circuit.rs.
+fn secp256k1() -> WeierstrassEllipticCurve {
+    WeierstrassEllipticCurve {
+        a: U256::from(0u64),
+        b: U256::from(7u64),
+        modulus: U256::from_str_radix(
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+            16,
+        )
+        .unwrap(),
+        gx: U256::from_str_radix(
+            "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+            16,
+        )
+        .unwrap(),
+        gy: U256::from_str_radix(
+            "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+            16,
+        )
+        .unwrap(),
+        order: U256::from_str_radix(
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+            16,
+        )
+        .unwrap(),
+    }
+}
+
+// Verbatim from src/bin/eval_circuit.rs.
+fn fiat_shamir_seed(ops: &[Op]) -> sha3::Shake256Reader {
+    let mut hasher = Shake256::default();
+    hasher.update(b"quantum_ecc-fiat-shamir-v2");
+    hasher.update(&(ops.len() as u64).to_le_bytes());
+    for op in ops {
+        hasher.update(&[op.kind as u8]);
+        hasher.update(&op.q_control2.0.to_le_bytes());
+        hasher.update(&op.q_control1.0.to_le_bytes());
+        hasher.update(&op.q_target.0.to_le_bytes());
+        hasher.update(&op.c_target.0.to_le_bytes());
+        hasher.update(&op.c_condition.0.to_le_bytes());
+        hasher.update(&op.r_target.0.to_le_bytes());
+    }
+    hasher.finalize_xof()
+}
+
+/// `src/sim.rs::apply_iter`, copied dispatch-for-dispatch, plus per-op attribution
+/// of `executed_shots`. Any divergence from the trusted loop shows up as a failed
+/// total-charge assertion, which is why that assertion is not optional.
+fn apply_iter_charged<R: XofReader>(
+    sim: &mut Simulator<'_, R>,
+    ops: &[Op],
+    charge: &mut [u64],
+    fire: &mut [u64],
+) {
+    let mut condition_stack: Vec<u64> = Vec::new();
+    let mut current_base_condition = u64::MAX;
+
+    for (i, op) in ops.iter().enumerate() {
+        let mut cond = current_base_condition;
+        if op.c_condition != NO_BIT {
+            cond &= sim.bit(op.c_condition);
+        }
+
+        let executed_shots = cond.count_ones() as u64;
+
+        match op.kind {
+            OperationType::CCZ | OperationType::CCX => {
+                sim.stats.toffoli_gates += executed_shots;
+                charge[i] += executed_shots;
+            }
+            OperationType::CX
+            | OperationType::CZ
+            | OperationType::Swap
+            | OperationType::R
+            | OperationType::Hmr => {
+                sim.stats.clifford_gates += executed_shots;
+            }
+            _ => {}
+        }
+
+        match op.kind {
+            OperationType::CCX => {
+                let v = cond & sim.qubit(op.q_control1) & sim.qubit(op.q_control2);
+                fire[i] += v.count_ones() as u64;
+                *sim.qubit_mut(op.q_target) ^= v;
+            }
+            OperationType::CX => {
+                let v = cond & sim.qubit(op.q_control1);
+                *sim.qubit_mut(op.q_target) ^= v;
+            }
+            OperationType::Swap => {
+                let mut q_c1 = sim.qubit(op.q_control1);
+                let mut q_t = sim.qubit(op.q_target);
+                q_c1 ^= q_t;
+                q_t ^= cond & q_c1;
+                q_c1 ^= q_t;
+                *sim.qubit_mut(op.q_control1) = q_c1;
+                *sim.qubit_mut(op.q_target) = q_t;
+            }
+            OperationType::X => {
+                *sim.qubit_mut(op.q_target) ^= cond;
+            }
+            OperationType::CCZ => {
+                let v = cond
+                    & sim.qubit(op.q_target)
+                    & sim.qubit(op.q_control1)
+                    & sim.qubit(op.q_control2);
+                fire[i] += v.count_ones() as u64;
+                sim.phase ^= v;
+            }
+            OperationType::CZ => {
+                let v = cond & sim.qubit(op.q_target) & sim.qubit(op.q_control1);
+                sim.phase ^= v;
+            }
+            OperationType::Z => {
+                let v = cond & sim.qubit(op.q_target);
+                sim.phase ^= v;
+            }
+            OperationType::Neg => {
+                sim.phase ^= cond;
+            }
+            OperationType::Hmr => {
+                let mut buf = [0u8; 8];
+                sim.xof.read(&mut buf);
+                let rng_val = u64::from_le_bytes(buf);
+                *sim.bit_mut(op.c_target) &= !cond;
+                *sim.bit_mut(op.c_target) ^= rng_val & cond;
+                sim.phase ^= sim.qubit(op.q_target) & rng_val & cond;
+                *sim.qubit_mut(op.q_target) &= !cond;
+            }
+            OperationType::R => {
+                let mut buf = [0u8; 8];
+                sim.xof.read(&mut buf);
+                let rng_val = u64::from_le_bytes(buf);
+                sim.phase ^= sim.qubit(op.q_target) & rng_val & cond;
+                *sim.qubit_mut(op.q_target) &= !cond;
+            }
+            OperationType::BitInvert => {
+                *sim.bit_mut(op.c_target) ^= cond;
+            }
+            OperationType::BitStore0 => {
+                *sim.bit_mut(op.c_target) &= !cond;
+            }
+            OperationType::BitStore1 => {
+                *sim.bit_mut(op.c_target) |= cond;
+            }
+            OperationType::AppendToRegister
+            | OperationType::Register
+            | OperationType::DebugPrint => {}
+            OperationType::PushCondition => {
+                condition_stack.push(current_base_condition);
+                current_base_condition &= sim.bit(op.c_condition);
+            }
+            OperationType::PopCondition => {
+                if let Some(val) = condition_stack.pop() {
+                    current_base_condition = val;
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let prefix = args.get(1).cloned().unwrap_or_else(|| "hot".to_string());
+    let write_files = prefix != "-";
+
+    let ops: Vec<Op> = point_add::build();
+    let (total_qubits, num_bits, _nregs, regs) = analyze_ops(ops.iter());
+    println!("ops={} qubits={} bits={}", ops.len(), total_qubits, num_bits);
+
+    let curve = secp256k1();
+    let mut xof = fiat_shamir_seed(&ops);
+
+    // Same draw and same rejection rules as eval_circuit::run_tests.
+    let mut targets = Vec::with_capacity(NUM_TESTS);
+    let mut offsets = Vec::with_capacity(NUM_TESTS);
+    for _ in 0..NUM_TESTS {
+        let mut rb = [[0u8; 32]; 2];
+        XofReader::read(&mut xof, &mut rb[0]);
+        XofReader::read(&mut xof, &mut rb[1]);
+        let k1 = U256::from_le_bytes(rb[0]);
+        let k2 = U256::from_le_bytes(rb[1]);
+        let t = curve.mul(curve.gx, curve.gy, k1);
+        let o = curve.mul(curve.gx, curve.gy, k2);
+        if t.0 == o.0 {
+            continue;
+        }
+        if t.0.is_zero() && t.1.is_zero() {
+            continue;
+        }
+        if o.0.is_zero() && o.1.is_zero() {
+            continue;
+        }
+        targets.push(t);
+        offsets.push(o);
+    }
+    let n = targets.len();
+    println!("shots={n}");
+
+    let mut charge = vec![0u64; ops.len()];
+    let mut fire = vec![0u64; ops.len()];
+    let mut sim = Simulator::new(total_qubits as usize, num_bits as usize, &mut xof);
+
+    assert_eq!(n % BATCH, 0, "partial final batch would need lane masking for fire counts");
+    let num_batches = (n + BATCH - 1) / BATCH;
+    for batch in 0..num_batches {
+        let bs = BATCH.min(n - batch * BATCH);
+        sim.clear_for_shot();
+        for shot in 0..bs {
+            let i = batch * BATCH + shot;
+            sim.set_register(&regs[0], targets[i].0, shot);
+            sim.set_register(&regs[1], targets[i].1, shot);
+            sim.set_register(&regs[2], offsets[i].0, shot);
+            sim.set_register(&regs[3], offsets[i].1, shot);
+        }
+        apply_iter_charged(&mut sim, &ops, &mut charge, &mut fire);
+    }
+
+    // ---- the gate: attribution must reconstruct the scorer's own total ----
+    let attributed: u64 = ops
+        .iter()
+        .enumerate()
+        .filter(|(_, op)| matches!(op.kind, OperationType::CCX | OperationType::CCZ))
+        .map(|(i, _)| charge[i])
+        .sum();
+    let total = sim.stats.toffoli_gates;
+    assert_eq!(
+        attributed, total,
+        "attribution does not reconstruct the scorer total"
+    );
+    let avg_t = total as f64 / n as f64;
+    let gates_n = ops
+        .iter()
+        .filter(|op| matches!(op.kind, OperationType::CCX | OperationType::CCZ))
+        .count();
+    println!("GATE ok: attributed={attributed} == toffoli_gates={total}");
+    println!("avgT={avg_t:.3}  (compare eval_circuit's 'avg executed Toffoli')");
+
+    // ---- the cooling bound ----
+    //
+    // A semantics-preserving condition must be TRUE on every shot where the gate
+    // fires, so the most any condition can save on gate g is
+    //     charge(g) - fire(g)
+    // shot-charges. Summed over the stream this is an absolute ceiling on the
+    // "make gates conditionally cold" lever, and it needs no candidate bit to be
+    // found -- it grants a perfect oracle condition to every gate at once.
+    let mut head_total: u64 = 0;
+    let mut fired_total: u64 = 0;
+    let mut dead_gates = 0usize;
+    let mut dead_charge = 0u64;
+    let mut always_fire = 0usize;
+    for (i, op) in ops.iter().enumerate() {
+        if !matches!(op.kind, OperationType::CCX | OperationType::CCZ) {
+            continue;
+        }
+        head_total += charge[i] - fire[i];
+        fired_total += fire[i];
+        if fire[i] == 0 {
+            dead_gates += 1;
+            dead_charge += charge[i];
+        }
+        if fire[i] == charge[i] {
+            always_fire += 1;
+        }
+    }
+    println!("\n=== COOLING BOUND (perfect-oracle condition on every gate) ===");
+    println!("total charge         : {total}");
+    println!("total fired          : {fired_total}  ({:.4}% of charge)", 100.0*fired_total as f64/total as f64);
+    println!("COOLING HEADROOM     : {head_total} shot-charges = {:.3} avgT ({:.4}% of score)",
+             head_total as f64 / n as f64, 100.0*head_total as f64/total as f64);
+    println!("gates that NEVER fire: {dead_gates} carrying {dead_charge} charge = {:.3} avgT",
+             dead_charge as f64 / n as f64);
+    println!("gates fired on every charged shot (uncoolable): {always_fire} ({:.3}%)",
+             100.0*always_fire as f64 / gates_n as f64);
+
+    // ---- distribution ----
+    let gates: Vec<(usize, &Op)> = ops
+        .iter()
+        .enumerate()
+        .filter(|(_, op)| matches!(op.kind, OperationType::CCX | OperationType::CCZ))
+        .collect();
+    println!("gates={}", gates.len());
+
+    let mut cold = 0usize;
+    let mut full = 0usize;
+    let mut partial = 0usize;
+    let mut charge_from_partial = 0u64;
+    for (i, _) in &gates {
+        let c = charge[*i];
+        if c == 0 {
+            cold += 1;
+        } else if c == n as u64 {
+            full += 1;
+        } else {
+            partial += 1;
+            charge_from_partial += c;
+        }
+    }
+    println!(
+        "COLD (charge=0)      : {cold} gates ({:.3}% of gates), 0 charge",
+        100.0 * cold as f64 / gates.len() as f64
+    );
+    println!(
+        "FULL (charge={n})   : {full} gates ({:.3}%), {} charge ({:.3}% of total)",
+        100.0 * full as f64 / gates.len() as f64,
+        full as u64 * n as u64,
+        100.0 * (full as u64 * n as u64) as f64 / total as f64
+    );
+    println!(
+        "PARTIAL              : {partial} gates ({:.3}%), {charge_from_partial} charge ({:.3}% of total)",
+        100.0 * partial as f64 / gates.len() as f64,
+        100.0 * charge_from_partial as f64 / total as f64
+    );
+
+    // Decile histogram over hotness, with the charge each decile carries.
+    let mut hist = [0usize; 11];
+    let mut hist_charge = [0u64; 11];
+    for (i, _) in &gates {
+        let h = charge[*i] as f64 / n as f64;
+        let b = ((h * 10.0).floor() as usize).min(10);
+        hist[b] += 1;
+        hist_charge[b] += charge[*i];
+    }
+    println!("\nHOTNESS DECILES (bucket = floor(hotness*10), 10 = exactly 1.0)");
+    println!("bucket\tgates\tshare_gates\tcharge\tshare_charge");
+    for b in 0..=10 {
+        println!(
+            "{}\t{}\t{:.4}%\t{}\t{:.4}%",
+            b,
+            hist[b],
+            100.0 * hist[b] as f64 / gates.len() as f64,
+            hist_charge[b],
+            100.0 * hist_charge[b] as f64 / total as f64
+        );
+    }
+
+    // Charge grouped by the op's own condition bit (NO_BIT = conditioned only by
+    // the enclosing PushCondition stack, if any).
+    let mut by_cond: HashMap<u64, (usize, u64)> = HashMap::new();
+    for (i, op) in &gates {
+        let e = by_cond.entry(op.c_condition.0).or_insert((0, 0));
+        e.0 += 1;
+        e.1 += charge[*i];
+    }
+    let mut bc: Vec<(u64, (usize, u64))> = by_cond.into_iter().collect();
+    bc.sort_by_key(|(_, (_, c))| std::cmp::Reverse(*c));
+    println!("\nTOP CONDITION BITS BY CHARGE (cond bit, gates, charge, share, mean hotness)");
+    for (cb, (ng, c)) in bc.iter().take(25) {
+        let label = if *cb == u64::MAX {
+            "NO_BIT".to_string()
+        } else {
+            cb.to_string()
+        };
+        println!(
+            "{}\t{}\t{}\t{:.4}%\t{:.4}",
+            label,
+            ng,
+            c,
+            100.0 * *c as f64 / total as f64,
+            *c as f64 / (*ng as f64 * n as f64)
+        );
+    }
+    println!("distinct_cond_bits={}", bc.len());
+
+    // Charge grouped by operand tuple -- the unit the strip keys on, so this is
+    // directly comparable to the census tables.
+    let mut by_tuple: HashMap<(u8, u64, u64, u64, u64), (usize, u64)> = HashMap::new();
+    for (i, op) in &gates {
+        let k = (
+            op.kind as u8,
+            op.q_control2.0,
+            op.q_control1.0,
+            op.q_target.0,
+            op.c_condition.0,
+        );
+        let e = by_tuple.entry(k).or_insert((0, 0));
+        e.0 += 1;
+        e.1 += charge[*i];
+    }
+    let mut bt: Vec<_> = by_tuple.into_iter().collect();
+    bt.sort_by_key(|(_, (_, c))| std::cmp::Reverse(*c));
+    println!("\nTOP OPERAND TUPLES BY CHARGE (kind,c2,c1,t,cond, occurrences, charge, share)");
+    for (k, (ng, c)) in bt.iter().take(25) {
+        println!(
+            "{},{},{},{},{}\t{}\t{}\t{:.4}%",
+            k.0,
+            k.1,
+            k.2,
+            k.3,
+            if k.4 == u64::MAX {
+                "NO_BIT".to_string()
+            } else {
+                k.4.to_string()
+            },
+            ng,
+            c,
+            100.0 * *c as f64 / total as f64
+        );
+    }
+    println!("distinct_tuples={}", bt.len());
+
+    if write_files {
+        let f = std::fs::File::create(format!("{prefix}.hot.tsv")).unwrap();
+        let mut w = std::io::BufWriter::new(f);
+        writeln!(w, "opidx\tkind\tc2\tc1\tt\tcond\tcharge\tfire\thead\thotness").unwrap();
+        for (i, op) in &gates {
+            writeln!(
+                w,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.6}",
+                i,
+                op.kind as u8,
+                op.q_control2.0,
+                op.q_control1.0,
+                op.q_target.0,
+                op.c_condition.0,
+                charge[*i],
+                fire[*i],
+                charge[*i] - fire[*i],
+                charge[*i] as f64 / n as f64
+            )
+            .unwrap();
+        }
+        println!("\nwrote {prefix}.hot.tsv");
+    }
+
+    let _ = (BitId(0), QubitId(0), QubitOrBit::Qubit(QubitId(0)));
+}


### PR DESCRIPTION
Adds 07-syntactic-certification.md: three closed routes to a stream-agnostic dead-gate certificate, each paired with a passing positive control, and the mechanism they share.

The target is the 46,286 CCX/CCZ (3.35% of the score, 43,237.5 avgT) that fire on none of the 9,024 official shots. The strict-beat bar is 0.802 avgT, so one certified gate is a submission -- but "never fired on this draw" cannot survive its own use, since the inputs are a SHAKE256 hash of the op stream (04-traps.md section 1).

  1. Cooling. No gate is charged on fewer than 4,330 of 9,024 shots and zero are cold. Every CCX/CCZ has c_condition = NO_BIT, so all conditioning comes from PushCondition blocks carrying Hmr outcomes, which are independent of the quantum controls -- hence the 0.5 band is a fair coin (mean 0.5000) and P(a gate's ~2,256 firing shots all land inside a fair coin's 4,512) = 2^-2256. Ceiling on the lever, granting a perfect oracle condition to all 1,347,438 gates, is 991,429 avgT = 76.74% of the score, and it is unreachable.

  2. Census sampling. Cannot certify the 46,286: a sampler observes firing and has no access to why a gate is quiet. This is the mechanism behind the depth-dependence 03-proven-floors.md already records under "Dead-gate census -- OVER-drawn, not dry".

  3. Affine relations over GF(2) with hash-consed AND terms. Not one gate has controls sharing a single atom; 6,754 of 1,342,695 terms collapse, the remaining 1.23M nonlinear terms are distinct.

All three reason about the FORM of a value. This circuit computes modular inversion and multiplication, so affine structure survives only through CX/X chains uninterrupted by any CCX, and no such chain reaches any control pair. Certifying any of the 46,286 needs a semantic argument over GCD data invariants -- plausibly BMC or SMT over one divstep lifted by induction.

Sections 1 and 3 are measured on the certified frontier cf5aa02; the instrument reproduces four entries of 06-research-status.md's table exactly (avgT 1,291,859.302, total Toffoli 11,657,738,337, ops 9,062,420, Q 1,154). Section 2 is on 6909d15 and says so.

Retains repro/hotness.rs, which is self-gating: it aborts unless the attributed charge reconstructs the scorer's own Toffoli total. That assertion caught a 9,216-shot draw that was plausible to the eye and wrong. Built like hyperplane_mitm.cpp -- copied out, compiled, scratch removed. constzero.rs and affine.rs stay in the fork but need no patching to run against an unmodified checkout.

Happy to also add a repro/hotness.rs row to 06-research-status.md's Retained files table and a §1 row to its Refuted-or-exhausted table -- left those out to keep this reviewable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/ecdsafail-challenge/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788467413&installation_model_id=21733&pr_number=27&repository=Layr-Labs%2Fecdsafail-challenge&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fecdsafail-challenge%2Fpull%2F27&signature=5d557df7ded098cf28b03c2bcd8f40ac21f326aca5723895aefaceba4b15f474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->