### PR TITLE
memory: lambda_total is 20.560 on 6909d15, and has not moved

### DIFF
--- a/src/point_add/memory/02-lambda.md
+++ b/src/point_add/memory/02-lambda.md
@@ -8,7 +8,101 @@ Fiat–Shamir seed moves, and with it the 9024 test inputs.
 
 That makes the nonce a clean experimental handle: vary it and you resample the test set from the same circuit.
 
-## The measurement (n=700, full 9024 shots each)
+## The current figure — `6909d15`, n=199
+
+Measured 2026-08-04 on `upstream/main` `6909d15`, score `1,486,468,554`, whose `src/` tree is identical to accepted
+submission `ed4b529`. 202 trials, each a full build plus a 9,024-shot `eval_circuit` — **no custom screen**
+(`04-traps.md` §4). 99 contiguous nonces, 100 at `2^40` stride, 3 controls.
+
+| statistic | classical | phase-garbage batches |
+|---|---|---|
+| mean | **17.126** | **11.628** |
+| sd (sem) | 4.149 (±0.294) | 3.473 (±0.246) |
+| var/mean | **1.005** | **1.037** |
+| range | 7..29 | 3..22 |
+| runs with zero | **0 / 199** | **0 / 199** |
+
+var/mean ≈ 1 on **both** channels is textbook Poisson with zero overdispersion, which independently proves the
+per-shot failure probability is identical at every nonce — i.e. the circuit really is nonce-invariant, and this is
+intrinsic error, not overfitting. Ancilla garbage is identically 0 by construction (see Traps below).
+
+Poisson-overlap estimator: `classical ~ Pois(λ_c + λ_both)`, `phase ~ Pois(λ_p + λ_both)` with independent
+components, so `Cov(c,p) = λ_both` and `λ_total = mean_c + mean_p − Cov`. Pearson ρ(c,p) = **0.569**.
+
+| | λ_total | P(clean) | trials/seed |
+|---|---|---|---|
+| lower bound, `max(means)` | 17.126 ± 0.294 | 3.7e-8 | 2.7e7 |
+| **covariance estimate** | **20.560** (95% CI 18.007–23.016) | **1.2e-9** | **8.5e8** |
+| upper bound, `sum(means)` | 28.754 ± 0.384 | 3.3e-13 | 3.1e12 |
+
+$$\lambda_{\text{total}} = 20.560 \quad\Rightarrow\quad P(\text{clean seed}) = e^{-20.560} = 1.2\times10^{-9}$$
+
+Decomposition **λ_classical_only 8.932, λ_both 8.193, λ_phase_only 3.435**. The CI is a 4,000-resample bootstrap over
+whole rows (seed 20260804). Direct observation alone bounds `P(clean)` only at < 1.5e-2 — rule of three on 0/199.
+
+**The phase channel alone costs 31×** — `e^(20.560 − 17.126)` — and almost every estimate in circulation quotes
+`e^-(classical mean)`.
+
+The estimator assumes the classical-only and phase-only components are mutually independent. If they are positively
+correlated beyond the shared term, λ_both is overstated and **λ_total is overestimated**, moving down toward the 17.13
+lower bound. The error is one-way, so the covariance estimate stays conservative for planning.
+
+### Method gates — all four passed before the sweep was trusted
+
+1. **Pristine baseline.** A clean `6909d15` tree builds to `ops.bin` md5 `ef30945f3afcb369192ea32897232d2f` at
+   **0/0/0**, avgT 1,288,101.386 × 1154 qubits = `1,486,468,554`, matching upstream exactly.
+2. **The control nonce is this head's own** — `200321420125`, baked in at `mod.rs:2384` — not `801dd20`'s
+   `62000008397024`. All three control rows returned 0/0/0 at the baseline md5.
+3. **The knob is live: 199/199 non-control nonces produced 199 distinct md5 values.** This is the check that catches
+   `benchmark.sh` preferring `sudo -n bwrap`, where sudo's `env_reset` strips `SUB4_TAIL_NONCE` before
+   `build_circuit` sees it and every trial silently re-measures the shipped nonce.
+4. **The analysis code was validated first**, by re-deriving every published `801dd20` figure from that sweep's raw
+   data before being pointed at this one.
+
+Raw data and full method live in
+[`austinamissah/ecdsa-circuit-optimization`](https://github.com/austinamissah/ecdsa-circuit-optimization):
+`docs/lambda-6909d15.md`, `docs/data/lambda-sweep-6909d15.tsv`.
+
+## λ has not moved
+
+| head | source | λ_total | classical | phase |
+|---|---|---|---|---|
+| `02146ca` | the n=700 fit below | 23.29 | 18.13 | 12.64 |
+| `801dd20` | `docs/lambda-measurement.md` | 20.04 | 16.231 | 10.915 |
+| **`6909d15`** | **this note, above** | **20.560** | **17.126** | **11.628** |
+
+Bootstrap on the difference `6909d15 − 801dd20` gives **+0.525, 95% CI −2.626 to +3.632, with 37% of resamples at or
+below zero.** On this evidence the two heads have the same λ_total.
+
+**That stability is the finding.** Eight accepted submissions and a better score moved λ by nothing measurable. Score
+work is neither paying for itself in λ nor costing anything in λ — it is not touching λ at all. Anyone planning
+against a moving λ, in either direction, is planning against noise.
+
+Both per-channel means did rise marginally — classical +0.894 (t = 2.24, p = 0.025), phase +0.714 (t = 2.12,
+p = 0.034) — but λ_both rose in step (7.111 → 8.193), which is why the channel movement does not propagate to the
+total. Two uncorrected comparisons at p ≈ 0.03 is weak evidence: worth noting, not worth acting on.
+
+`6909d15` scores **better** than `801dd20` (1,486,468,554 vs 1,487,590,242) while its channels run slightly
+**dirtier**. That is the score-versus-λ tension this note describes, showing up in upstream's own progress.
+
+**23.29 is stale.** It was measured on `02146ca` and the figure above supersedes it.
+
+### Clean seeds remain isolated, not clustered
+
+| block | n | classical | phase |
+|---|---|---|---|
+| A, contiguous `base+1 … base+99` | 99 | 17.354 ± 0.441 | 11.606 ± 0.328 |
+| B, `2^40` stride | 100 | 16.900 ± 0.391 | 11.650 ± 0.369 |
+
+Welch **t = +0.77** (classical) and **−0.09** (phase) — indistinguishable. A contiguous neighbourhood of the shipped
+clean nonce is no cleaner than nonces scattered across the space, reproducing the `801dd20` isolation result on a
+different head with a different base nonce. The closest any trial came to clean was `base+29` at 8 classical / 4
+phase. **Grinding near a known-good nonce buys nothing.**
+
+## The generative model — n=700 on `02146ca`
+
+Superseded as a λ figure by the section above, and retained because it is what established that phase-only failures
+exist at all.
 
 | statistic | classical | phase-garbage batches |
 |---|---|---|
@@ -18,20 +112,15 @@ That makes the nonce a clean experimental handle: vary it and you resample the t
 | range | 8..30 | 4..23 |
 | runs with zero | **0 / 700** | **0 / 700** |
 
-var/mean = 0.998 is textbook Poisson with zero overdispersion, which independently proves the per-shot failure
-probability is identical at every nonce — i.e. the circuit really is nonce-invariant, and this is intrinsic error, not
-overfitting.
-
 Pearson ρ(cm,pg) = 0.5205. Fitting on conditional means `E[pg|cm]` in bins cm=11..23 (20–69 nonces per bin, no
 extrapolation) discriminates decisively between two generative models:
 
 - **A** "phase ⊂ classical" (forces pg=0 when cm=0): SSE **13.37**, residuals systematically curved, and cannot reach
   the observed ρ at any parameter (best fit 0.835 vs observed 0.5205).
-- **B** "phase-only failures exist": SSE **2.44**. Fitted λ_classical_only 10.05, λ_both 8.08, λ_phase_only 5.16.
+- **B** "phase-only failures exist": SSE **2.44**. Fitted λ_classical_only 10.05, λ_both 8.08, λ_phase_only 5.16, so
+  λ_total 23.29.
 
-$$\lambda_{\text{total}} = 23.29 \quad\Rightarrow\quad P(\text{clean seed}) = e^{-23.29} = 7.7\times10^{-11}$$
-
-**The phase channel alone costs 175×** and almost every estimate in circulation quotes `e^-(classical mean)`.
+Model B is what the current figure refits: 8.932 / 8.193 / 3.435 is the same three-component shape on n=199.
 
 ## What this means
 
@@ -57,7 +146,8 @@ Exact classical emulation of the whole ModDiv incl. the Bezout apply, 6e6 sample
 | **model total** | **16.01** |
 | observed (n=700) | 18.13 |
 
-Residual ~2.1 is the square / non-ModDiv point arithmetic.
+Residual ~2.1 is the square / non-ModDiv point arithmetic. The source decomposition has not been re-run on
+`6909d15`, whose classical mean is 17.126; against that the same model total would leave a residual of ~1.1.
 
 ITERS tail curve (1e6-sample convergence distribution), mm per 9024:
 `258→5.228, 259→2.453, 260→1.114, 261→0.483, 262→0.200, 265→0.014`. Steep — the first extra iteration is worth a lot
@@ -89,8 +179,8 @@ width-independent, so it does NOT get cheaper at the tail).
 
 ## Statistics discipline
 
-Per-nonce sd is 4.25. **n=1 cannot distinguish Δλ=+7 from Δλ=0.** A reserve retune measured at n=1 as
-"cm 19, intrinsic, safe" was **+7.24 λ at n=12** (individual draws 19,21,22,23,23,24,25,27,28,29,31,32 — the first two
+Per-nonce sd is 4.25 (4.15 at n=199 on `6909d15` — unchanged in kind). **n=1 cannot distinguish Δλ=+7 from Δλ=0.**
+A reserve retune measured at n=1 as "cm 19, intrinsic, safe" was **+7.24 λ at n=12** (individual draws 19,21,22,23,23,24,25,27,28,29,31,32 — the first two
 sit inside the baseline range). Use n≥12, paired on the same nonce set, and quote a sigma.
 
 Also: avg-executed-Toffoli varies across nonces with sd 13.4 (n=700, span 86). So a single-nonce Toffoli comparison

--- a/src/point_add/memory/02-lambda.md
+++ b/src/point_add/memory/02-lambda.md
@@ -8,7 +8,26 @@ Fiat–Shamir seed moves, and with it the 9024 test inputs.
 
 That makes the nonce a clean experimental handle: vary it and you resample the test set from the same circuit.
 
-## The current figure — `6909d15`, n=199
+## Scope: this measures the trailmix construction, not what ships today
+
+**Added 2026-08-23.** Everything below was measured on the 1,154-qubit trailmix/dialog circuit, at
+`6909d15`, score `1,486,468,554`. That construction is now legacy: it is gated behind
+`SUB4_LEGACY_POINT_ADD`, and the shipping path is `pingpong_div.rs`, a fixed-depth ping-pong division
+at 1,278 qubits. `WAYFINDER.md` makes the same point about notes 01 to 06, and this file belongs in
+that group. The numbers here are kept as the record of what was measured then, not as a claim about
+the circuit that ships today.
+
+What carries over unchanged is the setup above and the method. The tail nonce is a clean handle on the
+test set for **any** construction, and the four method gates below apply to any lambda sweep on this
+harness. The sudo env-strip gate in particular is filed as issue #23 and is still live.
+
+For orientation, the same quantity on the current ping-pong circuit is about **18.75 classical
+mismatches per draw** (n=8, sd 6.0, measured 2026-08-23 at `SUB4_PP_ROUNDS=698` /
+`SUB4_PP_ROUNDS_MUL=696`), against the 17.126 recorded below for trailmix. The two are not directly
+comparable, since the constructions differ in every other respect, but the order of magnitude is the
+same and neither admits a clean seed by luck.
+
+## The measurement — `6909d15`, n=199
 
 Measured 2026-08-04 on `upstream/main` `6909d15`, score `1,486,468,554`, whose `src/` tree is identical to accepted
 submission `ed4b529`. 202 trials, each a full build plus a 9,024-shot `eval_circuit` — **no custom screen**


### PR DESCRIPTION
`02-lambda.md`'s λ_total of **23.29** was measured on `02146ca` and is stale. This replaces it with a measurement on `upstream/main` **`6909d15`** — the head whose `src/` tree is identical to accepted submission `ed4b529`.

**λ_total = 20.560 (95% CI 18.007–23.016)**, n=199 non-control trials. Decomposition λ_classical_only **8.932**, λ_both **8.193**, λ_phase_only **3.435**; ρ(c,p) = **0.569**. var/mean **1.005** classical and **1.037** phase — Poisson, no overdispersion. `P(clean)` moves from 7.7e-11 to **1.2e-9**, and the phase channel's standalone cost from 175× to **31×**.

**λ has not moved materially since `801dd20` (20.04).** The difference is **+0.525, 95% CI −2.626 to +3.632**, with **37% of bootstrap resamples at or below zero**. Eight accepted submissions and a better score have not moved λ measurably in either direction. That stability is the finding — it means planning against a moving λ, in either direction, is planning against noise.

Clean seeds remain isolated: 99 contiguous nonces and 100 at 2^40 stride are indistinguishable (Welch **t = +0.77** classical, **−0.09** phase). Grinding near a known-good nonce still buys nothing.

### Method gates — all four passed before the sweep was trusted

1. A pristine `6909d15` build reproduces `ops.bin` md5 `ef30945f3afcb369192ea32897232d2f` at **0/0/0**.
2. The control nonce is this head's own **`200321420125`**, not `801dd20`'s `62000008397024`.
3. **199/199** non-control nonces produced **199 distinct md5 values** — the check that catches `sudo`'s `env_reset` stripping `SUB4_TAIL_NONCE` before `build_circuit` sees it.
4. The analysis code was **validated first**, by re-deriving every published `801dd20` figure from that sweep's raw data before being pointed at this one.

Raw data and full method: [`austinamissah/ecdsa-circuit-optimization`](https://github.com/austinamissah/ecdsa-circuit-optimization) — `docs/lambda-6909d15.md`, `docs/data/lambda-sweep-6909d15.tsv`.

### Scope — and a smaller version on offer

This restructures `02-lambda.md` so the current figure leads and the n=700 material is demoted to what it uniquely establishes (the A-vs-B discrimination). If you'd prefer a minimal edit — just the number, `P(clean)`, and the 175× → 31× correction, leaving the structure alone — say so and I'll cut it down.

One line was deliberately left unchanged: **"roughly once per 1,100 inversions"** in *What this means*. Its derivation isn't stated in the note; on the λ_both reading it survives unchanged (9024/8.193 = 1,101), but if it came from elsewhere it may now be stale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/ecdsafail-challenge/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788475127&installation_model_id=21733&pr_number=28&repository=Layr-Labs%2Fecdsafail-challenge&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fecdsafail-challenge%2Fpull%2F28&signature=b54b0245a7e154fc846d73544ece467de003090267663632c51a5a404ef43a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->